### PR TITLE
delete tailing "-" from client name

### DIFF
--- a/bin/lib/Unifi.js
+++ b/bin/lib/Unifi.js
@@ -256,7 +256,7 @@ module.exports = class UniFi {
   }
 
   send(client) {
-    const name = client.name.replace(/[^a-z0-9]+/gi, '-');
+    const name = client.name.replace(/[^a-z0-9]+/gi, '-').replace(/-+$/, '');
     this.mqtt.send(`${this.config.topic}/${name}`, JSON.stringify(client));
   }
 };


### PR DESCRIPTION
If special characters are used at the end of clients, these are replaced by "-". This makes the MQTT topic very ugly.