### PR TITLE
Unifi Controller docker restart fix

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -88,6 +88,10 @@ const listenToEvents = async () => {
       sendStatus(states.DISCONNECTED);
       console.log('No Network, retry in 10 seconds');
       return new Promise((resolve) => setTimeout(resolve, 10000));
+    } else if (error.code === 'ECONNREFUSED' || error.code === 'ERR_BAD_REQUEST') {
+      sendStatus(states.DISCONNECTED);
+      console.log('Unifi Controller not reachable, retry in 10 seconds');
+      return new Promise((resolve) => setTimeout(resolve, 10000));
     }
 
     sendStatus(states.WAIT_FOR_CONFIG);


### PR DESCRIPTION
if a unifi-controller is running as a docker-container and it will be restartet it creates different errors a normal unifi-controller device would do.
So here is the missing else if.

* added check for "ECONNREFUSED" and "ERR_BAD_REQUEST"

Discussion link to the Forum:
https://www.loxforum.com/forum/projektforen/loxberry/plugins/323107-plugin-unifi-presence?p=384987#post384987